### PR TITLE
Return list instead of array

### DIFF
--- a/ADMPlugin/Plugin.cs
+++ b/ADMPlugin/Plugin.cs
@@ -28,9 +28,9 @@ namespace ADMPlugin
         {
         }
 
-        public Plugin(IProtobufSerializer protobufSerializer, 
-            IProtobufReferenceLayerSerializer protobufReferenceLayerSerializer, 
-            IAdmVersionInfoWriter admVersionInfoWriter, 
+        public Plugin(IProtobufSerializer protobufSerializer,
+            IProtobufReferenceLayerSerializer protobufReferenceLayerSerializer,
+            IAdmVersionInfoWriter admVersionInfoWriter,
             IAdmVersionInfoReader admVersionInfoReader,
             InternalJsonSerializer internalJsonSerializer)
         {
@@ -105,7 +105,7 @@ namespace ADMPlugin
 
             if (dataVersionModel == null)
                 return true;
-            
+
             var dataVersion = dataVersionModel.AdmVersion;
             var dataMajorVersion = dataVersion.Substring(0, currentVersion.IndexOf('.'));
 
@@ -127,7 +127,7 @@ namespace ADMPlugin
             var catalog = ImportData<Catalog>(path, CatalogAdm);
             var documents = _documentsImporter.ImportDocuments(path, DocumentAdm, catalog);
             var proprietaryValues = ImportData<List<ProprietaryValue>>(path, ProprietaryValuesAdm);
-            var referenceLayers = ImportReferenceLayers(path, ReferencelayersAdm); 
+            var referenceLayers = ImportReferenceLayers(path, ReferencelayersAdm);
 
             var applicationDataModel = new ApplicationDataModel
             {
@@ -137,7 +137,10 @@ namespace ADMPlugin
                 ReferenceLayers = referenceLayers
             };
 
-            return new[] { applicationDataModel };
+            return new List<ApplicationDataModel>
+            {
+                applicationDataModel
+            };
         }
 
         private IEnumerable<ReferenceLayer> ImportReferenceLayers(string path, string filename)
@@ -165,7 +168,7 @@ namespace ADMPlugin
         {
             _protobufReferenceLayerSerializer.Export(filePath, fileName, referenceLayers);
         }
-        
+
         private T ImportData<T>(string path, string searchPattern)
         {
             var files = Directory.GetFiles(path, searchPattern, SearchOption.AllDirectories);


### PR DESCRIPTION
It seems this sort of autoboxing is okay in C#/.Net land, whereas it
isn't in the Java world - certainly when we're using a third-party
library to proxy between the two.

This also now matches the method signature, which says it will return a
list and not an array.